### PR TITLE
Fix math library linking error

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 all: clean
-	gcc ./source/*.c -o main
+	gcc ./source/*.c -o main -lm
 
 clean:
 	rm -f main


### PR DESCRIPTION
By default, GCC does not automatically link the math library. Adding the `-lm` flag fixes the linking error.